### PR TITLE
CompatHelper + correction of indentation: 4-spaces per level

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/Project.toml
+++ b/Project.toml
@@ -8,5 +8,5 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-StaticArrays = "^0.12"
+StaticArrays = "^0.12, 1.0"
 julia = "^1.5"

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1,15 +1,14 @@
 """
-    AbsAttrib
+    AbsAttrib{T} <: AbstractArray{T,1}
 
 Abstract type of attribute. It is a subtype of AbstractArray.
 """
-abstract type AbsAttrib{T}<:AbstractArray{T, 1}
-end
+abstract type AbsAttrib{T} <: AbstractArray{T,1} end
 
 Base.IndexStyle(::Type{<:AbsAttrib}) = IndexLinear()
 
 """
-    VecAttrib{T}<:AbsAttrib{T}
+    VecAttrib{T} <: AbsAttrib{T}
 
 Attribute stores a quantity of type `T`, one value per shape.
 The value is indexed to the serial number of the object.
@@ -22,7 +21,7 @@ using StaticArrays
 using MeshCore: VecAttrib, ShapeColl, P1, attribute
 xyz = [0.0 0.0; 633.3333333333334 0.0; 1266.6666666666667 0.0]
 N, T = size(xyz, 2), eltype(xyz)
-locs =  VecAttrib([SVector{N, T}(xyz[i, :]) for i in 1:size(xyz, 1)])
+locs =  VecAttrib([SVector{N,T}(xyz[i, :]) for i in 1:size(xyz, 1)])
 vertices = ShapeColl(P1, size(xyz, 1))
 vertices.attributes["geom"] = locs
 a = attribute(vertices, "geom")
@@ -33,7 +32,7 @@ Attribute to label the vertices.
 using Test
 using StaticArrays
 using MeshCore: VecAttrib, ShapeColl, P1, attribute
-a = VecAttrib([1 for i in 1:size(xyz, 1)] )
+a = VecAttrib([1 for i in 1:size(xyz, 1)])
 vertices = ShapeColl(P1, size(xyz, 1))
 vertices.attributes["label"] = a
 @test a[3] == 1
@@ -45,15 +44,14 @@ struct VecAttrib{T} <: AbsAttrib{T}
     v::Vector{T}
 end
 
-
-Base.size(a::A) where {A<:VecAttrib} =  (length(a.v), )
+Base.size(a::A) where {A<:VecAttrib} = (length(a.v),)
 Base.getindex(a::A, i::Int) where {A<:VecAttrib} = a.v[i]
-Base.getindex(a::A, I::Vararg{Int, N}) where {A<:VecAttrib, N}  = a.v[I...]
-Base.setindex!(a::A, v, i::Int) where {A<:VecAttrib} =  (a.v[i] = v)  
-Base.setindex!(a::A, v, I::Vararg{Int, N}) where {A<:VecAttrib, N} = (a.v[I...] .= v) 
+Base.getindex(a::A, I::Vararg{Int,N}) where {A<:VecAttrib,N} = a.v[I...]
+Base.setindex!(a::A, v, i::Int) where {A<:VecAttrib} = (a.v[i] = v)
+Base.setindex!(a::A, v, I::Vararg{Int,N}) where {A<:VecAttrib,N} = (a.v[I...] .= v)
 
 """
-    FunAttrib{T, M, F} <: AbsAttrib{T}
+    FunAttrib{T,M,F} <: AbsAttrib{T}
 
 Attribute provides access to a quantity of type `T`, one value per shape.
 The value is indexed to the serial number of the object.
@@ -66,7 +64,7 @@ using StaticArrays
 using MeshCore: VecAttrib, ShapeColl, P1, attribute
 xyz = [0.0 0.0; 633.3333333333334 0.0; 1266.6666666666667 0.0]
 N, T = size(xyz, 2), eltype(xyz)
-flocs = FunAttrib(SVector{N, T}([0.0 0.0]), size(xyz, 1), i -> SVector{N, T}(xyz[i, :]))
+flocs = FunAttrib(SVector{N,T}([0.0 0.0]), size(xyz, 1), i -> SVector{N,T}(xyz[i, :]))
 @test flocs[10] == [633.3333333333334, 800.0]
 ```
 Attribute to label the vertices.
@@ -84,20 +82,19 @@ vertices.attributes["label"] = a
 The function attribute supports the methods `size`, `getindex`.
 It does not support `setindex!`: there is no way of changing the data.
 """
-struct FunAttrib{T, M, F} <: AbsAttrib{T}
+struct FunAttrib{T,M,F} <: AbsAttrib{T}
     z::T
     m::M
     f::F
 end
 
-Base.size(a::A) where {A<:FunAttrib} =  (a.m, )
+Base.size(a::A) where {A<:FunAttrib} = (a.m,)
 Base.getindex(a::A, i::Int) where {A<:FunAttrib} = a.f(i)
-Base.getindex(a::A, I::Vararg{Int, N}) where {A<:FunAttrib, N}  = a.f.(I...)
+Base.getindex(a::A, I::Vararg{Int,N}) where {A<:FunAttrib,N} = a.f.(I...)
 
 """
-    datavaluetype(AbsAttrib{T}) where {T} 
+    datavaluetype(AbsAttrib{T}) where {T}
 
 Retrieve the type of the attribute  value.
 """
 datavaluetype(a::AbsAttrib{T}) where {T} = T
-

--- a/src/increl.jl
+++ b/src/increl.jl
@@ -1,5 +1,5 @@
 """
-    IncRel{LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T}
+    IncRel{LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T}
 
 Incidence relation expressing connectivity between an entity of the shape on the
 left and a list of entities of the shape on the right.
@@ -31,12 +31,18 @@ or equivalently
 ir[55, 1]
 ```
 """
-struct IncRel{LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T}
-	left::ShapeColl{LEFT}
-	right::ShapeColl{RIGHT}
-	_v::Vector{T} # vector of vectors of shape numbers
+struct IncRel{LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T}
+    left::ShapeColl{LEFT}
+    right::ShapeColl{RIGHT}
+    _v::Vector{T} # vector of vectors of shape numbers
     name::String # name of the incidence relation
-    function IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, v::Vector{T}, name::String, internal) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T}
+    function IncRel(
+        left::ShapeColl{LEFT},
+        right::ShapeColl{RIGHT},
+        v::Vector{T},
+        name::String,
+        internal
+    ) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T}
         @_check (nshapes(left) == length(v))
         minn = typemax(eltype(v[1]))
         maxn = typemin(eltype(v[1]))
@@ -45,51 +51,69 @@ struct IncRel{LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T}
             maxn = max(maxn, maximum(abs.(v[i])))
         end
         @_check (nshapes(right) >= maxn)
-        return new{LEFT, RIGHT, T}(left, right, v, name)
+        return new{LEFT,RIGHT,T}(left, right, v, name)
     end
 end
 
 # Provide access to the incidence relation data as if it was a one-dimensional
 # or two dimensional array.
 Base.IndexStyle(::Type{<:IncRel}) = IndexLinear()
-Base.size(ir::IR) where {IR<:IncRel} =  (length(ir._v), )
+Base.size(ir::IR) where {IR<:IncRel} = (length(ir._v),)
 Base.getindex(ir::IR, i::Int) where {IR<:IncRel} = ir._v[i]
 Base.getindex(ir::IR, i::Int, k::Int) where {IR<:IncRel} = ir._v[i][k]
 
 """
-    IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, v::Vector{T}) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T}
+    IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, v::Vector{T}) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T}
 
 Convenience constructor with a vector of vectors and a default name.
 """
-function IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, v::Vector{T}) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T}
+function IncRel(
+    left::ShapeColl{LEFT},
+    right::ShapeColl{RIGHT},
+    v::Vector{T}
+) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T}
     IncRel(left, right, deepcopy(v), "(" * left.name * ", " * right.name * ")", true)
 end
 
 """
-    IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, v::Vector{T}, name::String) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T}
+    IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, v::Vector{T}, name::String) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T}
 
 Convenience constructor with a vector of vectors and a name.
 """
-function IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, v::Vector{T}, name::String) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T}
+function IncRel(
+    left::ShapeColl{LEFT},
+    right::ShapeColl{RIGHT},
+    v::Vector{T},
+    name::String
+) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T}
     IncRel(left, right, deepcopy(v), name, true)
 end
 
 """
-    IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, data::Matrix{MT}) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, MT}
+    IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, data::Matrix{MT}) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,MT}
 
 Convenience constructor supplying a matrix instead of a vector of vectors and a default name.
 """
-function IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, data::Matrix{MT}) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, MT}
+function IncRel(
+    left::ShapeColl{LEFT},
+    right::ShapeColl{RIGHT},
+    data::Matrix{MT}
+) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,MT}
     _v = [SVector{nvertices(left.shapedesc)}(data[idx, :]) for idx in 1:size(data, 1)]
-	IncRel(left, right, _v, "(" * left.name * ", " * right.name * ")", true)
+    IncRel(left, right, _v, "(" * left.name * ", " * right.name * ")", true)
 end
 
 """
-    IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, data::Matrix{MT}, name::String) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, MT}
+    IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, data::Matrix{MT}, name::String) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,MT}
 
 Convenience constructor supplying a matrix instead of a vector of vectors and a name.
 """
-function IncRel(left::ShapeColl{LEFT}, right::ShapeColl{RIGHT}, data::Matrix{MT}, name::String) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, MT}
+function IncRel(
+    left::ShapeColl{LEFT},
+    right::ShapeColl{RIGHT},
+    data::Matrix{MT},
+    name::String
+) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,MT}
     _v = [SVector{nvertices(left.shapedesc)}(data[idx, :]) for idx in 1:size(data, 1)]
     IncRel(left, right, _v, name, true)
 end
@@ -100,14 +124,14 @@ end
 Provide type of the incidence index (entity number).
 Presumably some type of integer.
 """
-indextype(ir::IncRel) = eltype(eltype(ir._v))  
+indextype(ir::IncRel) = eltype(eltype(ir._v))
 
 """
     nrelations(ir::IncRel)
 
 Number of individual relations in the incidence relation.
 """
-nrelations(ir::IncRel)  = length(ir._v)
+nrelations(ir::IncRel) = length(ir._v)
 
 """
     nentities(ir::IncRel, j::IT) where {IT}
@@ -117,17 +141,18 @@ Number of individual entities in the `j`-th relation in the incidence relation.
 nentities(ir::IncRel, j::IT) where {IT} = length(ir._v[j])
 
 """
-    code(ir::IncRel{LEFT, RIGHT, T}) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T} 
+    code(ir::IncRel{LEFT,RIGHT,T}) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T}
 
 Formulate the code of the incidence relation.
 """
-ir_code(ir::IncRel{LEFT, RIGHT, T}) where {LEFT<:AbsShapeDesc, RIGHT<:AbsShapeDesc, T} = (manifdim(shapedesc(ir.left)), manifdim(shapedesc(ir.right)))
+ir_code(ir::IncRel{LEFT,RIGHT,T}) where {LEFT<:AbsShapeDesc,RIGHT<:AbsShapeDesc,T} =
+    (manifdim(shapedesc(ir.left)), manifdim(shapedesc(ir.right)))
 
 """
     ir_transpose(ir::IncRel, name = "trp")
 
 Compute the "transposed" incidence relation `(d1, d2)`, where `d2 >= d1`.
-  
+
 This only makes sense for `d2 >= 0`. For `d2=1` we get for each vertex the list
 of edges connected to the vertex, and analogously faces and cells for `d=2` and
 `d=3`.
@@ -138,28 +163,28 @@ shape collection are swapped in the output relative to the input.
 """
 function ir_transpose(ir::IncRel, name = "trp")
     @_check (manifdim(ir.left) >= manifdim(ir.right))
-	inttype = eltype(ir._v[1])
+    inttype = eltype(ir._v[1])
     # Find out how many of the transpose incidence relations there are
-	nvmax = 0
-	for j in 1:nrelations(ir)
-		for k in 1:nentities(ir, j)
-			nvmax = max(nvmax, ir[j, k])
-		end
-	end
-	# pre-allocate relations vector
-	_v = Vector{inttype}[];
-	sizehint!(_v, nvmax)
-	# Initialize the relations to empty
+    nvmax = 0
+    for j in 1:nrelations(ir)
+        for k in 1:nentities(ir, j)
+            nvmax = max(nvmax, ir[j, k])
+        end
+    end
+    # pre-allocate relations vector
+    _v = Vector{inttype}[]
+    sizehint!(_v, nvmax)
+    # Initialize the relations to empty
     for i in 1:nvmax
         push!(_v, inttype[])  # initially empty arrays
     end
-	# Build the transpose relations
+    # Build the transpose relations
     for j in 1:nrelations(ir)
-		for k in 1:nentities(ir, j)
-			c = abs(ir[j, k]) # this could be an oriented entity: remove the sign
-			push!(_v[c], j)
-		end
-	end
+        for k in 1:nentities(ir, j)
+            c = abs(ir[j, k]) # this could be an oriented entity: remove the sign
+            push!(_v[c], j)
+        end
+    end
     return IncRel(ir.right, ir.left, _v, name)
 end
 
@@ -173,15 +198,15 @@ end
 
 function _mysortdim2!(A)
     # Sort each row  of A in ascending order.
-    m, n = size(A);
+    m, n = size(A)
     r = zeros(eltype(A), n)
     for k in 1:m
         for i in 1:n
-            r[i] = A[k,i]
+            r[i] = A[k, i]
         end
-        sort!(r);
+        sort!(r)
         for i in 1:n
-            A[k,i] = r[i]
+            A[k, i] = r[i]
         end
     end
     return A
@@ -189,17 +214,18 @@ end
 
 function _mysortrowsperm(A)
     # Sort the rows of A by sorting each column from back to front.
-    m,n = size(A);
-    indx = collect(1:m); sindx = zeros(eltype(A), m)
-    nindx = zeros(eltype(A), m);
+    m, n = size(A)
+    indx = collect(1:m)
+    sindx = zeros(eltype(A), m)
+    nindx = zeros(eltype(A), m)
     col = zeros(eltype(A), m)
-    for c = n:-1:1
+    for c in n:-1:1
         for i in 1:m
-            col[i] = A[indx[i],c]
+            col[i] = A[indx[i], c]
         end
-        #Sorting a column vector is much faster than sorting a column matrix
-        # sindx = sortperm(col, alg=QuickSort);
-        sortperm!(sindx, col, alg=QuickSort); # available for 0.4, slightly faster
+        # Sorting a column vector is much faster than sorting a column matrix
+        #sindx = sortperm(col, alg=QuickSort);
+        sortperm!(sindx, col, alg = QuickSort) # available for 0.4, slightly faster
         for i in 1:m
             nindx[i] = indx[sindx[i]]
         end
@@ -211,12 +237,12 @@ function _mysortrowsperm(A)
 end
 
 function _countrepeats(A)
-    m, n = size(A);
-    occurrences = zeros(eltype(A), m);
+    m, n = size(A)
+    occurrences = zeros(eltype(A), m)
     occurrences[1] = 1
     for i in 2:m
-        if A[i, :] == A[i-1, :]
-            occurrences[i] = occurrences[i-1] + 1
+        if A[i, :] == A[i - 1, :]
+            occurrences[i] = occurrences[i - 1] + 1
         else
             occurrences[i] = 1
         end
@@ -239,9 +265,9 @@ the manifold dimension of the shapes themselves). The right shape collection is
 the same as for the input.
 """
 function ir_skeleton(ir::IncRel, name = "skt")
-	@_check (manifdim(ir.right) == 0)
-	@_check (manifdim(ir.left) > 0)
-	inttype = eltype(ir._v[1])
+    @_check (manifdim(ir.right) == 0)
+    @_check (manifdim(ir.left) > 0)
+    inttype = eltype(ir._v[1])
     c = _asmatrix(ir, inttype) # incidence as a 2D array
     # construct a 2D array of the hyperface incidences
     hfc = c[:, facetconnectivity(ir.left, 1)]
@@ -257,8 +283,8 @@ function ir_skeleton(ir::IncRel, name = "skt")
     s2hfc = s2hfc[idx, :]
     rep = _countrepeats(s2hfc) # find the repeats of the rows
     # identify boundary facets: the hyperface is boundary if it has no repeats
-    isunq = [(rep[i] == 1) && (rep[i+1] == 1) for i in 1:length(rep)-1] 
-    push!(isunq,  (rep[end] == 1)) # and the last one
+    isunq = [(rep[i] == 1) && (rep[i + 1] == 1) for i in 1:(length(rep) - 1)]
+    push!(isunq, (rep[end] == 1)) # and the last one
     # unique rows are obtained by ignoring the repeats
     unq = findall(a -> a == 1, rep)
     unqhfc = shfc[unq, :] # unique hyper faces
@@ -277,24 +303,24 @@ The `skeleton` function.
 function ir_boundary(ir::IncRel, name = "bdr")
     sir = ir_skeleton(ir)
     isboundary = sir.left.attributes["isboundary"]
-    ind = [i for i in 1:length(isboundary) if isboundary[i]] 
+    ind = [i for i in 1:length(isboundary) if isboundary[i]]
     lft = ShapeColl(shapedesc(sir.left), length(ind), "facets")
     return IncRel(lft, sir.right, sir._v[ind], name)
 end
 
 function _selectrepeating(v, nrepeats)
-	m = length(v);
-    occurrences = zeros(eltype(v), m);
-	sort!(v)
-	occurrences[1] = 1
+    m = length(v)
+    occurrences = zeros(eltype(v), m)
+    sort!(v)
+    occurrences[1] = 1
     for i in 2:m
-        if v[i] == v[i-1]
-            occurrences[i] = occurrences[i-1] + 1
+        if v[i] == v[i - 1]
+            occurrences[i] = occurrences[i - 1] + 1
         else
             occurrences[i] = 1
         end
     end
-	repeats = [o == nrepeats for o in occurrences]
+    repeats = [o == nrepeats for o in occurrences]
     return v[repeats]
 end
 
@@ -326,43 +352,43 @@ manifold dimension of the shapes themselves).
     1st-order vertices of the facet shape.
 """
 function ir_bbyfacets(ir::IncRel, fir::IncRel, tfir::IncRel, name = "bbf")
-	@_check (manifdim(ir.right) == 0)
+    @_check (manifdim(ir.right) == 0)
     @_check (manifdim(fir.right) == 0)
     @_check (manifdim(tfir.left) == 0)
-	@_check manifdim(ir.left) == manifdim(tfir.right)+1
-	@_check manifdim(tfir.right) == manifdim(fir.left)
-	inttype = eltype(ir._v[1])
-	n1st = n1storderv(fir.left.shapedesc)
-	nshif = nshifts(fir.left.shapedesc)
-	# Sweep through the relations of (d, 0,) and use the (0, d-1) tfir
-	_c = fill(inttype(0), nrelations(ir), nfacets(ir.left))
+    @_check manifdim(ir.left) == manifdim(tfir.right) + 1
+    @_check manifdim(tfir.right) == manifdim(fir.left)
+    inttype = eltype(ir._v[1])
+    n1st = n1storderv(fir.left.shapedesc)
+    nshif = nshifts(fir.left.shapedesc)
+    # Sweep through the relations of (d, 0,) and use the (0, d-1) tfir
+    _c = fill(inttype(0), nrelations(ir), nfacets(ir.left))
     for i in 1:nrelations(ir) # Sweep through the relations of (d, 0)
-		sv = ir[i]
-		c = inttype[] # this will be the list of facets at the vertices of this entity
-		for j in 1:nentities(ir, i) # for all vertices
-			fv = ir[i, j]
-			for k in 1:nentities(tfir, fv)
-				push!(c, tfir[fv, k])
-			end # k
-		end
-		c = _selectrepeating(c, nvertices(tfir.right)) # keep the repeats
-		@_check length(c) == nfacets(ir.left)
-		# Now figure out the orientations
-		for k in 1:nfacets(ir.left)
-			fc = sv[facetconnectivity(ir.left, k)]
-			sfc = sort(fc)
-			for j in 1:length(c)
-				oc = fir[c[j]]
-				if sfc == sort(oc)
-					sgn = _sense(fc[1:n1st], oc, nshif)
-					_c[i, k] = sgn * c[j]
-					break;
-				end
-			end # j
-		end
-	end
-	bfacets = ShapeColl(fir.left.shapedesc, nshapes(tfir.right))
-	return IncRel(ir.left, bfacets, _c, name)
+        sv = ir[i]
+        c = inttype[] # this will be the list of facets at the vertices of this entity
+        for j in 1:nentities(ir, i) # for all vertices
+            fv = ir[i, j]
+            for k in 1:nentities(tfir, fv)
+                push!(c, tfir[fv, k])
+            end # k
+        end
+        c = _selectrepeating(c, nvertices(tfir.right)) # keep the repeats
+        @_check length(c) == nfacets(ir.left)
+        # Now figure out the orientations
+        for k in 1:nfacets(ir.left)
+            fc = sv[facetconnectivity(ir.left, k)]
+            sfc = sort(fc)
+            for j in 1:length(c)
+                oc = fir[c[j]]
+                if sfc == sort(oc)
+                    sgn = _sense(fc[1:n1st], oc, nshif)
+                    _c[i, k] = sgn * c[j]
+                    break
+                end
+            end # j
+        end
+    end
+    bfacets = ShapeColl(fir.left.shapedesc, nshapes(tfir.right))
+    return IncRel(ir.left, bfacets, _c, name)
 end
 
 """
@@ -376,7 +402,7 @@ is computed on the fly.
 # See also: [`ir_bbyfacets(ir::IncRel, fir::IncRel, tfir::IncRel)`](@ref)
 """
 function ir_bbyfacets(ir::IncRel, fir::IncRel, name = "bbf")
-	return ir_bbyfacets(ir, fir, ir_transpose(fir), name)
+    return ir_bbyfacets(ir, fir, ir_transpose(fir), name)
 end
 
 """
@@ -403,41 +429,41 @@ the manifold dimension of the shapes themselves).
     1st-order vertices of the ridge shape.
 """
 function ir_bbyridges(ir::IncRel, eir::IncRel, teir::IncRel, name = "bbr")
-	@_check (manifdim(ir.right) == 0) && (manifdim(teir.left) == 0)
-	@_check manifdim(ir.left) == manifdim(teir.right)+2
-	@_check manifdim(teir.right) == manifdim(eir.left)
-	inttype = eltype(ir._v[1])
-	n1st = n1storderv(eir.left.shapedesc)
-	nshif = nshifts(eir.left.shapedesc)
-	# Sweep through the relations of (d, 0), and use the (0, d-2) teir
-	_c = fill(inttype(0), nrelations(ir), nridges(ir.left))
-	for i in 1:nrelations(ir) # Sweep through the relations of (d, 0)
-		sv = ir[i]
-		c = inttype[] # this will be the list of facets at the vertices of this entity
-		for j in 1:nentities(ir, i) # for all vertices
-			fv = ir[i, j]
-			for k in 1:nentities(teir, fv)
-				push!(c, teir[fv, k])
-			end # k
-		end
-		c = _selectrepeating(c, nvertices(teir.right)) # keep the repeats
-		@_check length(c) == nridges(ir.left)
-		# Now figure out the orientations
-		for k in 1:nridges(ir.left)
-			fc = sv[ridgeconnectivity(ir.left, k)]
-			sfc = sort(fc)
-			for j in 1:length(c)
-				oc = eir[c[j]]
-				if sfc == sort(oc)
-					sgn = _sense(fc[1:n1st], oc, nshif)
-					_c[i, k] = sgn * c[j]
-					break;
-				end
-			end # j
-		end
-	end
-	bridges = ShapeColl(eir.left.shapedesc, nshapes(teir.right))
-	return IncRel(ir.left, bridges, _c, name)
+    @_check (manifdim(ir.right) == 0) && (manifdim(teir.left) == 0)
+    @_check manifdim(ir.left) == manifdim(teir.right) + 2
+    @_check manifdim(teir.right) == manifdim(eir.left)
+    inttype = eltype(ir._v[1])
+    n1st = n1storderv(eir.left.shapedesc)
+    nshif = nshifts(eir.left.shapedesc)
+    # Sweep through the relations of (d, 0), and use the (0, d-2) teir
+    _c = fill(inttype(0), nrelations(ir), nridges(ir.left))
+    for i in 1:nrelations(ir) # Sweep through the relations of (d, 0)
+        sv = ir[i]
+        c = inttype[] # this will be the list of facets at the vertices of this entity
+        for j in 1:nentities(ir, i) # for all vertices
+            fv = ir[i, j]
+            for k in 1:nentities(teir, fv)
+                push!(c, teir[fv, k])
+            end # k
+        end
+        c = _selectrepeating(c, nvertices(teir.right)) # keep the repeats
+        @_check length(c) == nridges(ir.left)
+        # Now figure out the orientations
+        for k in 1:nridges(ir.left)
+            fc = sv[ridgeconnectivity(ir.left, k)]
+            sfc = sort(fc)
+            for j in 1:length(c)
+                oc = eir[c[j]]
+                if sfc == sort(oc)
+                    sgn = _sense(fc[1:n1st], oc, nshif)
+                    _c[i, k] = sgn * c[j]
+                    break
+                end
+            end # j
+        end
+    end
+    bridges = ShapeColl(eir.left.shapedesc, nshapes(teir.right))
+    return IncRel(ir.left, bridges, _c, name)
 end
 
 """
@@ -451,7 +477,7 @@ is computed on the fly.
 # See also: [`ir_bbyridges(ir::IncRel, eir::IncRel, efir::IncRel)`](@ref)
 """
 function ir_bbyridges(ir::IncRel, eir::IncRel, name = "bbr")
-	return ir_bbyridges(ir, eir, ir_transpose(eir), name)
+    return ir_bbyridges(ir, eir, ir_transpose(eir), name)
 end
 
 """
@@ -464,9 +490,17 @@ to itself.
 """
 function ir_identity(ir::IncRel, side = :left)
     if side == :left
-        return IncRel(ir.left, ir.left, [SVector{1, Int64}([idx]) for idx in 1:nshapes(ir.left)])
+        return IncRel(
+            ir.left,
+            ir.left,
+            [SVector{1,Int64}([idx]) for idx in 1:nshapes(ir.left)],
+        )
     else
-        return IncRel(ir.right, ir.right, [SVector{1, Int64}([idx]) for idx in 1:nshapes(ir.right)])
+        return IncRel(
+            ir.right,
+            ir.right,
+            [SVector{1,Int64}([idx]) for idx in 1:nshapes(ir.right)],
+        )
     end
 end
 
@@ -487,5 +521,5 @@ end
 Form a brief summary of the incidence relation.
 """
 function Base.summary(ir::IncRel)
-    return "$(ir.name): " * summary(ir.left) * ", " * summary(ir.right) 
+    return "$(ir.name): " * summary(ir.left) * ", " * summary(ir.right)
 end

--- a/src/shapedesc.jl
+++ b/src/shapedesc.jl
@@ -1,6 +1,5 @@
-
 """
-    AbsShapeDesc
+    AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Abstract shape descriptor (simplex, or cuboid, of various manifold dimension)
 
@@ -20,137 +19,162 @@ properties of the shape S:
 - `facets` = definitions of the shapes on the boundary of the shape S in terms
     of local connectivity
 - `ridgedesc` = shape descriptor of the shapes on the boundary of the boundary
-  of the shape S (which we call ridges here),
+    of the shape S (which we call ridges here),
 - `ridges` = definitions of the shapes on the boundary of the boundary of the
-  shape S in terms of local connectivity
+    shape S in terms of local connectivity
 
 The bit-type values are defined with the type parameters:
-- `MD` is the manifold dimension, 
-- `NV` is the number of connected vertices, 
-- `NF` is the number of boundary facets, 
+- `MD` is the manifold dimension,
+- `NV` is the number of connected vertices,
+- `NF` is the number of boundary facets,
 - `FD` is the descriptor of the facet (boundary shape).
-- `NR` is the number of boundary ridges, 
+- `NR` is the number of boundary ridges,
 - `RD` is the descriptor of the ridge (boundary shape).
-- `NFOV` is number of first-order vertices, 
+- `NFOV` is number of first-order vertices,
 - `NSHIFTS` is the number of shifts that should be attempted when matching
-  shapes to determine orientation.
+    shapes to determine orientation.
 """
-abstract type AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
-end
+abstract type AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} end
 
 """
-    manifdim(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    manifdim(sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 What is the manifold dimension of this shape?
 """
-manifdim(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} = MD
+manifdim(
+    sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS},
+) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} = MD
 
 """
-    nvertices(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    nvertices(sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 How many vertices does the shape connect?
 """
-nvertices(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} = NV
+nvertices(
+    sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS},
+) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} = NV
 
 """
-    nfacets(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    nfacets(sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 How many facets bound the shape?
 """
-nfacets(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} = NF
+nfacets(
+    sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS},
+) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} = NF
 
 """
-    nridges(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    nridges(sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 How many ridges bound the shape?
 """
-nridges(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} = NR
+nridges(
+    sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS},
+) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} = NR
 
 """
-    n1storderv(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    n1storderv(sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 How many 1st-order vertices are there per shape?
 
 For instance, for hexahedra each shape has 8 1st-order vertices.
 """
-n1storderv(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} = NFOV
+n1storderv(
+    sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS},
+) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} = NFOV
 
 """
-    nshifts(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    nshifts(sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 How many circular shifts should be tried to figure out the orientation (sense)?
 """
-nshifts(sd::AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}) where {MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} = NSHIFTS
+nshifts(
+    sd::AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS},
+) where {MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} = NSHIFTS
 
 """
     NoSuchShapeDesc
 
 Base descriptor: no shape is of this description.
 """
-struct NoSuchShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
-end
+struct NoSuchShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} end
 
 const NoSuchShape = NoSuchShapeDesc{
-0,  # MD
-0,  # NV
-0,  # NF
-0,  # FD
-0,  # NR
-0,  # RD
-0, # NFOV
-0 # NSHIFTS
+    0, # MD
+    0, # NV
+    0, # NF
+    0, # FD
+    0, # NR
+    0, # RD
+    0, # NFOV
+    0, # NSHIFTS
 }()
 
 """
-    P1ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    P1ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a point shape.
 """
-struct P1ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct P1ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 0, Int64, 0}
+    facets::SMatrix{NF,0,Int64,0}
     ridgedesc::RD
-    ridges::SMatrix{NR, 0, Int64, 0}
+    ridges::SMatrix{NR,0,Int64,0}
     name::String
 end
 
 const P1 = P1ShapeDesc{
-0,  # MD
-1,  # NV
-0,  # NF
-NoSuchShapeDesc,  # FD
-0,  # NR
-NoSuchShapeDesc,  # RD
-1, # NFOV
-0 # NSHIFTS
-}(NoSuchShape, SMatrix{0, 0}(Int64[]), NoSuchShape, SMatrix{0, 0}(Int64[]), "P1")
+    0, # MD
+    1, # NV
+    0, # NF
+    NoSuchShapeDesc, # FD
+    0, # NR
+    NoSuchShapeDesc, # RD
+    1, # NFOV
+    0, # NSHIFTS
+}(
+    NoSuchShape,
+    SMatrix{0,0}(Int64[]),
+    NoSuchShape,
+    SMatrix{0,0}(Int64[]),
+    "P1",
+)
 
 """
-    L2ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    L2ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a line segment shape.
 """
-struct L2ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct L2ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 1, Int64, 2}
+    facets::SMatrix{NF,1,Int64,2}
     ridgedesc::RD
-    ridges::SMatrix{NR, 0, Int64, 0}
+    ridges::SMatrix{NR,0,Int64,0}
     name::String
 end
 
 const L2 = L2ShapeDesc{
-1,  # MD
-2,  # NV
-2,  # NF
-P1ShapeDesc,  # FD
-0,  # NR
-NoSuchShapeDesc,  # RD
-2, # NFOV
-0 # NSHIFTS
-}(P1, SMatrix{2, 1}([1; 2]), NoSuchShape, SMatrix{0, 0}(Int64[]), "L2")
+    1, # MD
+    2, # NV
+    2, # NF
+    P1ShapeDesc, # FD
+    0, # NR
+    NoSuchShapeDesc, # RD
+    2, # NFOV
+    0, # NSHIFTS
+}(
+    P1,
+    SMatrix{2,1}([1; 2]),
+    NoSuchShape,
+    SMatrix{0,0}(Int64[]),
+    "L2",
+)
 
 """
-    Q4ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    Q4ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a quadrilateral shape.
 
@@ -159,27 +183,34 @@ coordinate along the edge increases.
 
 Ridges: Counterclockwise.
 """
-struct Q4ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct Q4ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 2, Int64, 4*2}
+    facets::SMatrix{NF,2,Int64,4 * 2}
     ridgedesc::RD
-    ridges::SMatrix{NR, 1, Int64, 4*1}
+    ridges::SMatrix{NR,1,Int64,4 * 1}
     name::String
 end
 
 const Q4 = Q4ShapeDesc{
-2,  # MD
-4,  # NV
-4,  # NF
-L2ShapeDesc, # FD
-4,  # NR
-P1ShapeDesc,  # RD
-4,  # NFOV
-4 # NSHIFTS
-}(L2, SMatrix{4, 2}([1 4; 2 3; 1 2; 4 3]), P1, SMatrix{4, 1}([1; 2; 3; 4]), "Q4")
+    2, # MD
+    4, # NV
+    4, # NF
+    L2ShapeDesc, # FD
+    4, # NR
+    P1ShapeDesc, # RD
+    4, # NFOV
+    4, # NSHIFTS
+}(
+    L2,
+    SMatrix{4,2}([1 4; 2 3; 1 2; 4 3]),
+    P1,
+    SMatrix{4,1}([1; 2; 3; 4]),
+    "Q4",
+)
 
 """
-    H8ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    H8ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a hexahedral shape.
 
@@ -190,28 +221,34 @@ looking from the outside.
 Ridges: First the four edges parallel to xi, then the four parallel to eta, and
 finally the four parallel to zeta.
 """
-struct H8ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct H8ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 4, Int64, 6*4}
+    facets::SMatrix{NF,4,Int64,6 * 4}
     ridgedesc::RD
-    ridges::SMatrix{NR, 2, Int64, 12*2}
+    ridges::SMatrix{NR,2,Int64,12 * 2}
     name::String
 end
 
 const H8 = H8ShapeDesc{
-3,  # MD
-8,  # NV
-6,  # NF
-Q4ShapeDesc, # FD
-12, # NR
-L2ShapeDesc, # RD
-8, # NFOV
-0 # NSHIFTS
-}(Q4, SMatrix{6, 4}(
-[8 4 1 5; 7 6 2 3; 6 5 1 2; 7 3 4 8; 3 2 1 4; 7 8 5 6]), L2, SMatrix{12, 2}([8 7; 5 6; 1 2; 4 3; 6 7; 5 8; 1 4; 2 3; 3 7; 4 8; 1 5; 2 6];), "H8")
+    3, # MD
+    8, # NV
+    6, # NF
+    Q4ShapeDesc, # FD
+    12, # NR
+    L2ShapeDesc, # RD
+    8, # NFOV
+    0, # NSHIFTS
+}(
+    Q4,
+    SMatrix{6,4}([8 4 1 5; 7 6 2 3; 6 5 1 2; 7 3 4 8; 3 2 1 4; 7 8 5 6]),
+    L2,
+    SMatrix{12,2}([8 7; 5 6; 1 2; 4 3; 6 7; 5 8; 1 4; 2 3; 3 7; 4 8; 1 5; 2 6];),
+    "H8",
+)
 
 """
-    T3ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    T3ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a triangular shape.
 
@@ -220,26 +257,34 @@ vertex 2 and so on. The vertices define counterclockwise orientation.
 
 Ridges: The vertices in counterclockwise order.
 """
-struct T3ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct T3ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 2, Int64, 3*2}
+    facets::SMatrix{NF,2,Int64,3 * 2}
     ridgedesc::RD
-    ridges::SMatrix{NR, 1, Int64, 3*1}
+    ridges::SMatrix{NR,1,Int64,3 * 1}
     name::String
 end
 
-const T3 = T3ShapeDesc{2, # MD
-3, # NV
-3, # NF
-L2ShapeDesc, # FD
-3, # NR
-P1ShapeDesc, # RD
-3, # NFOV
-3 # NSHIFTS
-}(L2, SMatrix{3, 2}([2 3; 3 1; 1 2]), P1, SMatrix{3, 1}([1; 2; 3]), "T3")
+const T3 = T3ShapeDesc{
+    2, # MD
+    3, # NV
+    3, # NF
+    L2ShapeDesc, # FD
+    3, # NR
+    P1ShapeDesc, # RD
+    3, # NFOV
+    3, # NSHIFTS
+}(
+    L2,
+    SMatrix{3,2}([2 3; 3 1; 1 2]),
+    P1,
+    SMatrix{3,1}([1; 2; 3]),
+    "T3",
+)
 
 """
-    T4ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    T4ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a tetrahedral shape.
 
@@ -252,50 +297,65 @@ right-hand side rotation rule: rotate about an edge (ridge) as if it was a
 rotation vector  with positive orientation. The vertices on the edge opposite
 across the tetrahedron are traversed in the order given by the rotation.
 """
-struct T4ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct T4ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 3, Int64, 4*3}
+    facets::SMatrix{NF,3,Int64,4 * 3}
     ridgedesc::RD
-    ridges::SMatrix{NR, 2, Int64, 6*2}
+    ridges::SMatrix{NR,2,Int64,6 * 2}
     name::String
 end
 
-const T4 = T4ShapeDesc{3,  # MD
-4,  # NV
-4,  # NF
-T3ShapeDesc, # FD
-6,  # NR
-L2ShapeDesc, # RD
-4, # NFOV
-0 # NSHIFTS
-}(T3, SMatrix{4, 3}([2 3 4; 1 4 3; 4 1 2; 3 2 1]), L2, SMatrix{6, 2}([1 4; 2 3; 1 2; 3 4; 4 2; 1 3]), "T4")
+const T4 = T4ShapeDesc{
+    3, # MD
+    4, # NV
+    4, # NF
+    T3ShapeDesc, # FD
+    6, # NR
+    L2ShapeDesc, # RD
+    4, # NFOV
+    0, # NSHIFTS
+}(
+    T3,
+    SMatrix{4,3}([2 3 4; 1 4 3; 4 1 2; 3 2 1]),
+    L2,
+    SMatrix{6,2}([1 4; 2 3; 1 2; 3 4; 4 2; 1 3]),
+    "T4",
+)
 
 """
-    L3ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    L3ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a quadratic line segment shape.
 """
-struct L3ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct L3ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 1, Int64, 2}
+    facets::SMatrix{NF,1,Int64,2}
     ridgedesc::RD
-    ridges::SMatrix{NR, 0, Int64, 0}
+    ridges::SMatrix{NR,0,Int64,0}
     name::String
 end
 
 const L3 = L3ShapeDesc{
-1,  # MD
-3,  # NV
-2,  # NF
-P1ShapeDesc,  # FD
-0,  # NR
-NoSuchShapeDesc,  # RD
-2, # NFOV
-0 # NSHIFTS
-}(P1, SMatrix{2, 1}([1; 2]), NoSuchShape, SMatrix{0, 0}(Int64[]), "L3")
+    1, # MD
+    3, # NV
+    2, # NF
+    P1ShapeDesc, # FD
+    0, # NR
+    NoSuchShapeDesc, # RD
+    2, # NFOV
+    0, # NSHIFTS
+}(
+    P1,
+    SMatrix{2,1}([1; 2]),
+    NoSuchShape,
+    SMatrix{0,0}(Int64[]),
+    "L3",
+)
 
 """
-    T6ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    T6ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a quadratic triangular shape.
 
@@ -304,26 +364,34 @@ vertex 2 and so on. The vertices define counterclockwise orientation.
 
 Ridges: The vertices in counterclockwise order.
 """
-struct T6ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct T6ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 3, Int64, 3*3}
+    facets::SMatrix{NF,3,Int64,3 * 3}
     ridgedesc::RD
-    ridges::SMatrix{NR, 1, Int64, 3*1}
+    ridges::SMatrix{NR,1,Int64,3 * 1}
     name::String
 end
 
-const T6 = T6ShapeDesc{2, # MD
-6, # NV
-3, # NF
-L3ShapeDesc, # FD
-3, # NR
-P1ShapeDesc, # RD
-3, # NFOV
-3 # NSHIFTS
-}(L3, SMatrix{3, 3}([2 3 5; 3 1 6; 1 2 4]), P1, SMatrix{3, 1}([1; 2; 3]), "T6")
+const T6 = T6ShapeDesc{
+    2, # MD
+    6, # NV
+    3, # NF
+    L3ShapeDesc, # FD
+    3, # NR
+    P1ShapeDesc, # RD
+    3, # NFOV
+    3, # NSHIFTS
+}(
+    L3,
+    SMatrix{3,3}([2 3 5; 3 1 6; 1 2 4]),
+    P1,
+    SMatrix{3,1}([1; 2; 3]),
+    "T6",
+)
 
 """
-    Q8ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+    Q8ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <: AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
 
 Shape descriptor of a quadrilateral shape.
 
@@ -332,34 +400,51 @@ coordinate along the edge increases.
 
 Ridges: Counterclockwise.
 """
-struct Q8ShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS} <: AbsShapeDesc{MD, NV, NF, FD, NR, RD, NFOV, NSHIFTS}
+struct Q8ShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS} <:
+       AbsShapeDesc{MD,NV,NF,FD,NR,RD,NFOV,NSHIFTS}
     facetdesc::FD
-    facets::SMatrix{NF, 3, Int64, 4*3}
+    facets::SMatrix{NF,3,Int64,4 * 3}
     ridgedesc::RD
-    ridges::SMatrix{NR, 1, Int64, 4*1}
+    ridges::SMatrix{NR,1,Int64,4 * 1}
     name::String
 end
 
 const Q8 = Q8ShapeDesc{
-2,  # MD
-8,  # NV
-4,  # NF
-L3ShapeDesc, # FD
-4,  # NR
-P1ShapeDesc,  # RD
-4,  # NFOV
-4 # NSHIFTS
-}(L3, SMatrix{4, 3}([1 4 8; 2 3 6; 1 2 5; 4 3 7]), P1, SMatrix{4, 1}([1; 2; 3; 4]), "Q8")
+    2, # MD
+    8, # NV
+    4, # NF
+    L3ShapeDesc, # FD
+    4, # NR
+    P1ShapeDesc, # RD
+    4, # NFOV
+    4, # NSHIFTS
+}(
+    L3,
+    SMatrix{4,3}([1 4 8; 2 3 6; 1 2 5; 4 3 7]),
+    P1,
+    SMatrix{4,1}([1; 2; 3; 4]),
+    "Q8",
+)
 
 """
     SHAPE_DESC
 
 Dictionary of all the descriptors.
 """
-const SHAPE_DESC = Dict("P1"=>P1, "L2"=>L2, "T3"=>T3, "T4"=>T4, "Q4"=>Q4, "H8"=>H8, "L3"=>L3, "T6"=>T6, "Q8"=>Q8)
+const SHAPE_DESC = Dict(
+    "P1" => P1,
+    "L2" => L2,
+    "T3" => T3,
+    "T4" => T4,
+    "Q4" => Q4,
+    "H8" => H8,
+    "L3" => L3,
+    "T6" => T6,
+    "Q8" => Q8,
+)
 
 """
-    nfeatofdim(sd::SD, m) where {SD <: AbsShapeDesc}
+    nfeatofdim(sd::SD, m) where {SD<:AbsShapeDesc}
 
 Compute number of manifold features of given dimension.
 
@@ -372,7 +457,7 @@ to the hierarchy of cells, facets, ridges. Internal vertices must be accounted
 for as well. For instance, L3 has two facets, but three vertices. T6 has three
 facets, three ridges, but six vertices.
 """
-function nfeatofdim(sd::SD, m) where {SD <: AbsShapeDesc}
+function nfeatofdim(sd::SD, m) where {SD<:AbsShapeDesc}
     if m > manifdim(sd)
         return 0
     end

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -1,33 +1,33 @@
 """
-    ShapeColl{S <: AbsShapeDesc}
+    ShapeColl{S<:AbsShapeDesc}
 
 This is the type of a homogeneous collection of finite element shapes.
 
 - `S` = shape descriptor: subtype of AbsShapeDesc.
 """
-struct ShapeColl{S <: AbsShapeDesc}
+struct ShapeColl{S<:AbsShapeDesc}
     shapedesc::S # Shape descriptor
-	nshapes::Int64 # Number of shapes in the collection
-	attributes::Dict{String, AbsAttrib} # dictionary of attributes
+    nshapes::Int64 # Number of shapes in the collection
+    attributes::Dict{String,AbsAttrib} # dictionary of attributes
     name::String # name of the shape collection
 end
 
 """
-    ShapeColl(shapedesc::S, nshapes::Int64) where {S <: AbsShapeDesc}
+    ShapeColl(shapedesc::S, nshapes::Int64) where {S<:AbsShapeDesc}
 
 Set up new shape collection with an empty dictionary of attributes and a default name.
 """
-function ShapeColl(shapedesc::S, nshapes::Int64) where {S <: AbsShapeDesc}
-	ShapeColl(shapedesc::S, nshapes, Dict{String, AbsAttrib}(), "shapes")
+function ShapeColl(shapedesc::S, nshapes::Int64) where {S<:AbsShapeDesc}
+    ShapeColl(shapedesc::S, nshapes, Dict{String,AbsAttrib}(), "shapes")
 end
 
 """
-    ShapeColl(shapedesc::S, nshapes::Int64, s::String) where {S <: AbsShapeDesc}
+    ShapeColl(shapedesc::S, nshapes::Int64, s::String) where {S<:AbsShapeDesc}
 
 Set up new shape collection with an empty dictionary of attributes.
 """
-function ShapeColl(shapedesc::S, nshapes::Int64, s::String) where {S <: AbsShapeDesc}
-    ShapeColl(shapedesc::S, nshapes, Dict{String, AbsAttrib}(), s)
+function ShapeColl(shapedesc::S, nshapes::Int64, s::String) where {S<:AbsShapeDesc}
+    ShapeColl(shapedesc::S, nshapes, Dict{String,AbsAttrib}(), s)
 end
 
 """
@@ -112,16 +112,16 @@ Retrieve a named attribute.
 attribute(shapes::ShapeColl, s::String) = shapes.attributes[s]
 
 function _sense(fc, oc, nshifts) # is the facet used in the positive or in the negative sense?
-	if fc == oc
-		return +1 # facet used in the positive sense
-	end
-	for i in 1:nshifts-1
-		fc = circshift(fc, 1) # try a circular shift
-		if fc == oc
-			return +1 # facet used in the positive sense
-		end
-	end
-	return -1 # facet used in the positive sense
+    if fc == oc
+        return +1 # facet used in the positive sense
+    end
+    for i in 1:(nshifts - 1)
+        fc = circshift(fc, 1) # try a circular shift
+        if fc == oc
+            return +1 # facet used in the positive sense
+        end
+    end
+    return -1 # facet used in the positive sense
 end
 
 """
@@ -138,6 +138,6 @@ function Base.summary(sc::S) where {S<:ShapeColl}
         end
         s = s * "}"
     end
-    
+
     return s
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -6,14 +6,16 @@ macro _check(ex, msgs...)
     elseif !isempty(msgs) && (isa(msg, Expr) || isa(msg, Symbol))
         # message is an expression needing evaluating
         msg = :(Main.Base.string($(esc(msg))))
-    elseif isdefined(Main, :Base) && isdefined(Main.Base, :string) && applicable(Main.Base.string, msg)
+    elseif isdefined(Main, :Base) &&
+           isdefined(Main.Base, :string) &&
+           applicable(Main.Base.string, msg)
         msg = Main.Base.string(msg)
     else
         # string() might not be defined during bootstrap
         msg = quote
-            msg = $(Expr(:quote,msg))
+            msg = $(Expr(:quote, msg))
             isdefined(Main, :Base) ? Main.Base.string(msg) :
-                (Core.println(msg); "Error during bootstrap. See stdout.")
+            (Core.println(msg); "Error during bootstrap. See stdout.")
         end
     end
     return :($(esc(ex)) ? $(nothing) : throw(AssertionError($msg)))


### PR DESCRIPTION
Dear Petr,

recently I took an interest in your package MeshCore. During the study of the code I took an additional time to hopefully made the code more clear in terms of formatting. Main changes: (i) consistent indentation (4-spaces per level) and (ii) formatting of the code in more native Julia way. Furthermore, I added CompatHelper, as I had a problem with StaticArray dependency due to recent update to 1.0.x.

Ondra