### PR TITLE
Correction of bug in I::Vararg{Int,N} based getindex for VecAttrib and FunAttrib, plus test coverage.

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -46,9 +46,9 @@ end
 
 Base.size(a::A) where {A<:VecAttrib} = (length(a.v),)
 Base.getindex(a::A, i::Int) where {A<:VecAttrib} = a.v[i]
-Base.getindex(a::A, I::Vararg{Int,N}) where {A<:VecAttrib,N} = a.v[I...]
+Base.getindex(a::A, I::Vararg{Int,N}) where {A<:VecAttrib,N} = a.v[[I...]]
 Base.setindex!(a::A, v, i::Int) where {A<:VecAttrib} = (a.v[i] = v)
-Base.setindex!(a::A, v, I::Vararg{Int,N}) where {A<:VecAttrib,N} = (a.v[I...] .= v)
+Base.setindex!(a::A, v, I::Vararg{Int,N}) where {A<:VecAttrib,N} = (a.v[[I...]] .= v)
 
 """
     FunAttrib{T,M,F} <: AbsAttrib{T}
@@ -90,7 +90,7 @@ end
 
 Base.size(a::A) where {A<:FunAttrib} = (a.m,)
 Base.getindex(a::A, i::Int) where {A<:FunAttrib} = a.f(i)
-Base.getindex(a::A, I::Vararg{Int,N}) where {A<:FunAttrib,N} = a.f.(I...)
+Base.getindex(a::A, I::Vararg{Int,N}) where {A<:FunAttrib,N} = a.f.([I...])
 # The `show` method may need some more work. It doesn't seem to play nice with @show .
 Base.show(io::IOContext{Base.TTY}, unused::MIME{Symbol("text/plain")}, a::X) where {X<:FunAttrib} = let 
     print(io, "$(a.m)-element FunAttrib")

--- a/test/attributes_tests.jl
+++ b/test/attributes_tests.jl
@@ -1,0 +1,29 @@
+@testset "VecAttrib" begin
+    using MeshCore: VecAttrib, datavaluetype
+    attribute = VecAttrib([i for i in 1:10])
+    
+    @test IndexStyle(attribute) == IndexLinear()
+    @test size(attribute) == (10,)
+    for i in 1:10
+        @test attribute[i] == i
+    end
+    @test attribute[1,2,3,2,1] == [1,2,3,2,1]
+    attribute[1] = 100
+    @test attribute[1] == 100
+    attribute[1,2,10] = [100,200,1000]
+    @test attribute[1,2,10] == [100,200,1000]
+    @test datavaluetype(attribute) == Int
+end
+
+@testset "FunAttrib" begin
+    using MeshCore: FunAttrib, datavaluetype
+    fun_attribute = FunAttrib(0, 10, x -> x)
+
+    @test IndexStyle(fun_attribute) == IndexLinear()
+    @test size(fun_attribute) == (10,)
+    for i in 1:10
+        @test fun_attribute[i] == i
+    end
+    @test fun_attribute[1,2,3,2,1] == [1,2,3,2,1]
+    @test datavaluetype(fun_attribute) == Int
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,5 @@
 using Test
-@time @testset "Mesh core" begin include("test_core.jl") end
+@time @testset "Mesh core" begin
+    include("test_core.jl")
+    include("attributes_tests.jl")
+end


### PR DESCRIPTION
Hi Petr,

I found small bug in getindex implementations.

O.