### PR TITLE
Adds corrections for Julia v1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Petr Krysl <pkrysl@ucsd.edu>"]
 version = "1.3.2"
 
 [deps]
+TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/MeshCore.jl
+++ b/src/MeshCore.jl
@@ -1,6 +1,7 @@
 module MeshCore
 
 using StaticArrays
+using TupleTools: sort
 
 include("utilities.jl")
 include("attributes.jl")

--- a/src/increl.jl
+++ b/src/increl.jl
@@ -188,7 +188,7 @@ end
 function _asmatrix(ir, inttype)
     c = fill(inttype(0), nshapes(ir.left), nvertices(shapedesc(ir.left)))
     for i in 1:nshapes(ir.left)
-        c[i, :] = ir[i]
+        c[i, :] .= ir[i]
     end
     return c
 end
@@ -376,8 +376,8 @@ function ir_bbyfacets(ir::IncRel, fir::IncRel, tfir::IncRel, name = "bbf")
             sfc = sort(fc)
             for j in 1:length(c)
                 oc = fir[c[j]]
-                if sfc == sort(oc)
-                    sgn = _sense(fc[1:n1st], oc, nshif)
+                if sfc == sort(oc.data)
+                    sgn = _sense(fc[1:n1st], oc.data, nshif)
                     _c[i, k] = sgn * c[j]
                     break
                 end


### PR DESCRIPTION
I tried to use MeshCore on Julia v1.9.2 and I ran into some internal errors in MeshCore. After some debugging, these changes solved the problem:

- Adds TupleTools to enable sorting of tuple, direct sorting over a tuple was not working in v1.9.
- Adds explicit elementwise operations that were not working in v1.9.
- Adds explicit access to StaticArray data to enable some operations, also not working in v1.9.

Would be nice to have this available in the official release.

Thanks!

-artur palha